### PR TITLE
Better prefix stats (total-size) + global readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,25 +78,24 @@ Here is an example of what the output from `redis-keys-statistics` might look li
 
 ```
 
-### Detailed Prefix Statistics
+### Stats per prefix (sorted by 'total size')
 ```
-+-------------+-------+--------------+---------+-----------------+
-| Prefix Name | Count | Average Size | Max TTL | Types           |
-+-------------+-------+--------------+---------+-----------------+
-| user        | 100   | 200 KB       | 3600    | - Type: hash    |
-|             |       |              |         |   Count: 50     |
-|             |       |              |         | - Type: string  |
-|             |       |              |         |   Count: 50     |
-| cache       | 80    | 150 KB       | -1      | - Type: zset    |
-|             |       |              |         |   Count: 80     |
-| config      | 20    | 100 KB       | 86400   | - Type: hash    |
-|             |       |              |         |   Count: 20     |
-| temp        | 150   | 50 KB        | 1800    | - Type: set     |
-|             |       |              |         |   Count: 100    |
-|             |       |              |         | - Type: list    |
-|             |       |              |         |   Count: 50     |
-+-------------+-------+--------------+---------+-----------------+
-
++-------------+------------+-------+------------------+---------+-----------------+
+| Key prefix  | Total Size | Count | Avg size per key | Max TTL | Types           |
++-------------+------------+-------+------------------+---------+-----------------+
+| user        | 20 MB      | 100   | 200 KB           | 3600    | - Type: hash    |
+|             |            |       |                  |         |   Count: 50     |
+|             |            |       |                  |         | - Type: string  |
+|             |            |       |                  |         |   Count: 50     |
+| cache       | 12 MB      | 80    | 150 KB           | -1      | - Type: zset    |
+|             |            |       |                  |         |   Count: 80     |
+| temp        | 7.5 MB     | 150   | 50 KB            | 1800    | - Type: set     |
+|             |            |       |                  |         |   Count: 100    |
+|             |            |       |                  |         | - Type: list    |
+|             |            |       |                  |         |   Count: 50     |
+| config      | 2 MB       | 20    | 100 KB           | 86400   | - Type: hash    |
+|             |            |       |                  |         |   Count: 20     |
++-------------+------------+-------+------------------+---------+-----------------+
 ```
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ optional arguments:
 ## Example Output
 Here is an example of what the output from `redis-keys-statistics` might look like:
 
-### Top 20 Largest Keys in Redis
+### Top 20 largest (individual) keys
 ```
 +-------------------+------+---------+------------+-------+
 | Key               | Type | Size    | Size Ratio |  TTL  |
@@ -61,7 +61,6 @@ Here is an example of what the output from `redis-keys-statistics` might look li
 | temp:data:456     | set  | 500 KB  | 60% ↑      | 1800  |
 | ...               | ...  | ...     | ...        |  ...  |
 +-------------------+------+---------+------------+-------+
-
 ```
 
 ### Key Count by Type
@@ -75,7 +74,6 @@ Here is an example of what the output from `redis-keys-statistics` might look li
 | set    | 75    |
 | string | 200   |
 +--------+-------+
-
 ```
 
 ### Stats per prefix (sorted by 'total size')

--- a/rks/display.py
+++ b/rks/display.py
@@ -39,19 +39,23 @@ def analyze_redis_keys(min_heap, prefix_statistics_map, total_key_size, total_ke
     print(table)
 
     table = PrettyTable()
-    table.title = "Detailed Prefix Statistics"
-    table.field_names = ["Prefix Name", "Count", "Average Size", "Max TTL", "Types"]
+    table.title = "Stats per prefix (sorted by 'total size')"
+    table.field_names = ["Key prefix", "Total Size", "Count", "Avg size per key", "Max TTL", "Types"]
 
-    for prefix, item in prefix_statistics_map.items():
+    sorted_prefix_stats = sorted(prefix_statistics_map.items(), key=lambda x: x[1]['total_size'], reverse=True)
 
-        prefix_average_size = round(item['total_size'] / item['count'], 2) if item['count'] != 0 else 0
+    for prefix, item in sorted_prefix_stats:
+
+        prefix_total_size = item['total_size']
+        prefix_average_size = round(prefix_total_size / item['count'], 2) if item['count'] != 0 else 0
 
         if use_pretty:
+            prefix_total_size = format_memory_size(prefix_total_size)
             prefix_average_size = format_memory_size(prefix_average_size)
 
         types = ""
         for key_type, type_count in item['type_count'].items():
             types += " - Type: {}, Count: {}\n".format(key_type.decode('utf-8'), type_count)
-        table.add_row([prefix.decode('utf-8', errors='ignore'), item['count'], prefix_average_size, item['max_ttl'], types])
+        table.add_row([prefix.decode('utf-8', errors='ignore'), prefix_total_size, item['count'], prefix_average_size, item['max_ttl'], types])
 
     print(table)

--- a/rks/display.py
+++ b/rks/display.py
@@ -5,11 +5,16 @@ def analyze_redis_keys(min_heap, prefix_statistics_map, total_key_size, total_ke
 
     average_key_size = total_key_size / total_key_count if total_key_count != 0 else 0
 
-    print("\n" + "-"*25 + f"\nAnalyzing DB {db_num}\n" + "-"*25 + "\n")
+    print("\n" + "#"*25 + f"\nAnalyzing DB {db_num}\n" + "#"*25 + "\n")
+
+    average_key_size_pretty = average_key_size
+    if use_pretty:
+        average_key_size_pretty = format_memory_size(average_key_size_pretty)
+    print(f"Found: {total_key_count} keys, average size (per key): {average_key_size_pretty}\n")
 
     table = PrettyTable()
-    table.title = "Top 20 largest keys in Redis"
-    table.field_names = ["Key", "Type", "Size", "Size Ratio", "TTL"]
+    table.title = "Top 20 largest (individual) keys"
+    table.field_names = ["Key", "Type", "Size", "Size ratio (vs avg)", "TTL"]
 
     sorted_items = sorted(min_heap, key=lambda x: x[0], reverse=True)
 


### PR DESCRIPTION
_NB: PR started with copilot, but fully reviewed & modified manually by me afterwards ;)_

## What/why ?

This PR contains 2 things (cf its 2 separate commits):

1. The main improvement is about the **stats per prefix**:
    => adds a `Total size` column and sorts rows by this size (instead of no sorting at all, it was "random") to be able to spot the biggest usage in the redis DB more efficiently

2. And the 2nd part is a "boyscout" move:
   => slightly improve **readability** of output globally (more precise naming and formatting)

## Test
I tested it locally like this:
```
## Create a few keys:
redis-server &
for i in `seq 1 10000`; do redis-cli set users:$i plopplopplopplopplopplop; done
for i in `seq 1 25000`; do redis-cli set orders:$i plopplopplopplopplopplopplopplopplopplopplopplop; done
redis-cli hset global:config1 name aaa desc loremipsumloremipsum timeout 10
redis-cli hset global:config2 name bbbbbb desc loremipsumloremipsum timeout 20
redis-cli hset global:config3 name ccccccccc desc loremipsumloremipsum timeout 30

## And executed the tool:
cd ~/git/redis-keys-statistics/
python3 -m venv venv/
source venv/bin/activate
pip3 install setuptools
pip3 install -r requirements.txt
python3 -m rks.main --host localhost --port 6379 --pretty
```

And got:
```
#########################
Analyzing DB 0
#########################

Found: 35003 keys, average size (per key):  86.86 B

+-----------------------------------------------------------------+
|                 Top 20 largest (individual) keys                |
+----------------+--------+-----------+---------------------+-----+
|      Key       |  Type  |    Size   | Size ratio (vs avg) | TTL |
+----------------+--------+-----------+---------------------+-----+
| global:config3 |  hash  |  111.00 B |       27.8% ↑       |  -1 |
| global:config2 |  hash  |  108.00 B |       24.3% ↑       |  -1 |
| global:config1 |  hash  |  105.00 B |       20.9% ↑       |  -1 |
|  orders:9984   | string |   96.00 B |       10.5% ↑       |  -1 |
|  orders:9985   | string |   96.00 B |       10.5% ↑       |  -1 |
|  orders:9989   | string |   96.00 B |       10.5% ↑       |  -1 |
|  orders:9986   | string |   96.00 B |       10.5% ↑       |  -1 |
|  orders:9992   | string |   96.00 B |       10.5% ↑       |  -1 |
|   orders:999   | string |   96.00 B |       10.5% ↑       |  -1 |
|  orders:9990   | string |   96.00 B |       10.5% ↑       |  -1 |
|  orders:9988   | string |   96.00 B |       10.5% ↑       |  -1 |
|  orders:9987   | string |   96.00 B |       10.5% ↑       |  -1 |
|  orders:9994   | string |   96.00 B |       10.5% ↑       |  -1 |
|  orders:9996   | string |   96.00 B |       10.5% ↑       |  -1 |
|  orders:9995   | string |   96.00 B |       10.5% ↑       |  -1 |
|  orders:9998   | string |   96.00 B |       10.5% ↑       |  -1 |
|  orders:9993   | string |   96.00 B |       10.5% ↑       |  -1 |
|  orders:9991   | string |   96.00 B |       10.5% ↑       |  -1 |
|  orders:9999   | string |   96.00 B |       10.5% ↑       |  -1 |
|  orders:9997   | string |   96.00 B |       10.5% ↑       |  -1 |
+----------------+--------+-----------+---------------------+-----+
+-------------------+
| Key Count by Type |
+---------+---------+
|   Type  |  Count  |
+---------+---------+
|  string |  35000  |
|   hash  |    3    |
+---------+---------+
+----------------------------------------------------------------------------------------------+
|                          Stats per prefix (sorted by 'total size')                           |
+------------+------------+-------+------------------+---------+-------------------------------+
| Key prefix | Total Size | Count | Avg size per key | Max TTL |             Types             |
+------------+------------+-------+------------------+---------+-------------------------------+
|   orders   |  2.29 MB   | 25000 |      96.00 B     |    -1   |  - Type: string, Count: 25000 |
|            |            |       |                  |         |                               |
|   users    | 625.00 KB  | 10000 |      64.00 B     |    -1   |  - Type: string, Count: 10000 |
|            |            |       |                  |         |                               |
|   global   |  324.00 B  |   3   |     108.00 B     |    -1   |     - Type: hash, Count: 3    |
|            |            |       |                  |         |                               |
+------------+------------+-------+------------------+---------+-------------------------------+
```